### PR TITLE
Set useNativeDriver to true for smooth animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | **pressInFriction** number  | No            |               | 
 | **pressOutTension** number  | No            |               | 
 | **pressOutFriction** number | No            |               | 
+| **useNativeDriver** boolean | No            | true          | 
 
 ## Install
 

--- a/src/TouchableScale.js
+++ b/src/TouchableScale.js
@@ -79,6 +79,7 @@ export default class TouchableScale extends React.Component {
             toValue: props.activeScale,
             tension: tension,
             friction: friction,
+            useNativeDriver: true,
         }).start();
 
         if (props.onPressIn) {
@@ -96,6 +97,7 @@ export default class TouchableScale extends React.Component {
             toValue: props.defaultScale,
             tension: tension,
             friction: friction,
+            useNativeDriver: true,
         }).start();
 
         if (props.onPressOut) {

--- a/src/TouchableScale.js
+++ b/src/TouchableScale.js
@@ -33,6 +33,7 @@ import { TouchableWithoutFeedback, Animated } from 'react-native';
  * @property {number} [pressInFriction]
  * @property {number} [pressOutTension]
  * @property {number} [pressOutFriction]
+ * @property {boolean} [useNativeDriver]
  */
 export default class TouchableScale extends React.Component {
     constructor(...args) {
@@ -79,7 +80,7 @@ export default class TouchableScale extends React.Component {
             toValue: props.activeScale,
             tension: tension,
             friction: friction,
-            useNativeDriver: true,
+            useNativeDriver: props.useNativeDriver,
         }).start();
 
         if (props.onPressIn) {
@@ -97,7 +98,7 @@ export default class TouchableScale extends React.Component {
             toValue: props.defaultScale,
             tension: tension,
             friction: friction,
-            useNativeDriver: true,
+            useNativeDriver: props.useNativeDriver,
         }).start();
 
         if (props.onPressOut) {
@@ -117,6 +118,7 @@ TouchableScale.propTypes = {
     pressInFriction: PropTypes.number,
     pressOutTension: PropTypes.number,
     pressOutFriction: PropTypes.number,
+    useNativeDriver: PropTypes.bool,
 };
 
 TouchableScale.defaultProps = {
@@ -124,4 +126,5 @@ TouchableScale.defaultProps = {
     activeScale: 0.9,
     tension: 150,
     friction: 3,
+    useNativeDriver: true,
 };


### PR DESCRIPTION
This allows smooth animations. Even if JS thread is doing some expensive task it would behave well, since the animation run on the UI thread.

An easy way to see the difference is:
1. Set `Debug JS remotely`
1. Add a `debugger` line to the button `onPress` handler.

With `useNativeDriver: true` the animation will perform but without that the animation will stop, because the animation runs in the JS thread which is stopped by the `debugger`.

References:
https://facebook.github.io/react-native/blog/2017/02/14/using-native-driver-for-animated.html
https://facebook.github.io/react-native/docs/animated.html