### PR TITLE
fix: update TypeScript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.1",
   "description": "Like TouchableOpacity, but scale.",
   "main": "index.js",
+  "types": "react-native-touchable-scale.d.ts",
   "peerDependencies": {
     "react": ">=0.13.2 || ^0.14 || ^15.0.0",
     "react-native": ">=0.19.0"

--- a/react-native-touchable-scale.d.ts
+++ b/react-native-touchable-scale.d.ts
@@ -1,10 +1,8 @@
 declare module 'react-native-touchable-scale' {
   import React from 'react';
-  import { StyleProp } from 'react-native';
-  import { TouchableWithoutFeedbackProps, ViewStyle } from 'react-native';
+  import { TouchableWithoutFeedbackProps } from 'react-native';
 
   export interface TouchableScaleProps extends TouchableWithoutFeedbackProps {
-    style?: StyleProp<ViewStyle>;
     defaultScale?: number;
     activeScale?: number;
     tension?: number;
@@ -16,5 +14,5 @@ declare module 'react-native-touchable-scale' {
     useNativeDriver?: boolean;
   }
 
-  export default class TouchableScale<T> extends React.Component<TouchableScaleProps> { }
+  export default class TouchableScale extends React.Component<TouchableScaleProps> {}
 }


### PR DESCRIPTION
Hi! 👋🏽 

TypeScript automatically looks for an `index.d.ts` file in each repo. If you have a different name, it must be specified in the `types` or `typings` property in the `package.json` file.

Besides doing the above, this PR removes an unnecessary prop (`style`) since it's inherited from `TouchableWithoutFeedbackProps` automatically and the generics `T` since it doesn't apply to this library.

Closes #4.