### PR TITLE
Import ViewPropTypes from 'deprecated-react-native-prop-types' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/kohver/react-native-touchable-scale#readme",
   "dependencies": {
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "deprecated-react-native-prop-types": "^2.3.0"
   }
 }

--- a/src/TouchableScale.js
+++ b/src/TouchableScale.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types'
-import { TouchableWithoutFeedback, Animated, ViewPropTypes } from 'react-native';
+import PropTypes from 'prop-types';
+import { TouchableWithoutFeedback, Animated } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 /**
  * @typedef {Object} TouchableWithoutFeedbackProps


### PR DESCRIPTION
`ViewPropTypes` will be deprecated in a future version of React Native. This PR uses the prop-types from the [deprecated-react-native-prop-types](https://www.npmjs.com/package/deprecated-react-native-prop-types) to prevent deprecation warnings.